### PR TITLE
muqss: fix lockdep-enabled build

### DIFF
--- a/kernel/sched/MuQSS.c
+++ b/kernel/sched/MuQSS.c
@@ -1272,7 +1272,7 @@ void set_task_cpu(struct task_struct *p, unsigned int cpu)
 	 * task_rq_lock().
 	 */
 	WARN_ON_ONCE(debug_locks && !(lockdep_is_held(&p->pi_lock) ||
-				      lockdep_is_held(rq->lock)));
+				      lockdep_is_held(&rq->lock)));
 #endif
 	trace_sched_migrate_task(p, cpu);
 	perf_event_task_migrate(p);


### PR DESCRIPTION
Fix by passing rq->lock pointer to lockdep_is_held():

In file included from ./arch/x86/include/asm/bug.h:81:0,
                 from ./include/linux/bug.h:4,
                 from ./include/linux/thread_info.h:11,
                 from ./arch/x86/include/asm/preempt.h:6,
                 from ./include/linux/preempt.h:80,
                 from ./include/linux/spinlock.h:50,
                 from ./include/linux/rcupdate.h:38,
                 from ./include/linux/rculist.h:10,
                 from ./include/linux/pid.h:4,
                 from ./include/linux/sched.h:13,
                 from kernel/sched/MuQSS.c:33:
kernel/sched/MuQSS.c: In function ‘set_task_cpu’:
./include/linux/lockdep.h:351:52: error: invalid type argument of ‘->’ (have ‘raw_spinlock_t {aka struct raw_spinlock}’)
 #define lockdep_is_held(lock)  lock_is_held(&(lock)->dep_map)
                                                    ^~
./include/asm-generic/bug.h:65:25: note: in definition of macro ‘WARN_ON_ONCE’
  int __ret_warn_on = !!(condition);   \
                         ^~~~~~~~~
kernel/sched/MuQSS.c:1275:11: note: in expansion of macro ‘lockdep_is_held’
           lockdep_is_held(rq->lock)));
           ^~~~~~~~~~~~~~~

Signed-off-by: Sergey Senozhatsky <sergey.senozhatsky@gmail.com>