### PR TITLE
4.14.15 incompatible change

### DIFF
--- a/kernel/sched/MuQSS.c
+++ b/kernel/sched/MuQSS.c
@@ -55,6 +55,7 @@
 #include <linux/security.h>
 #include <linux/syscalls.h>
 #include <linux/tick.h>
+#include <linux/version.h>
 
 #include <asm/switch_to.h>
 #include <asm/tlb.h>
@@ -1959,7 +1960,11 @@ try_to_wake_up(struct task_struct *p, unsigned int state, int wake_flags)
 	p->state = TASK_WAKING;
 
 	if (p->in_iowait) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 15)
 		delayacct_blkio_end();
+#else
+		delayacct_blkio_end(p);
+#endif
 		atomic_dec(&task_rq(p)->nr_iowait);
 	}
 
@@ -1970,7 +1975,11 @@ try_to_wake_up(struct task_struct *p, unsigned int state, int wake_flags)
 #else /* CONFIG_SMP */
 
 	if (p->in_iowait) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 15)
 		delayacct_blkio_end();
+#else
+		delayacct_blkio_end(p);
+#endif
 		atomic_dec(&task_rq(p)->nr_iowait);
 	}
 
@@ -2022,7 +2031,11 @@ static void try_to_wake_up_local(struct task_struct *p)
 
 	if (!task_on_rq_queued(p)) {
 		if (p->in_iowait) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 14, 15)
 			delayacct_blkio_end();
+#else
+			delayacct_blkio_end(p);
+#endif
 			atomic_dec(&rq->nr_iowait);
 		}
 		ttwu_activate(rq, p);


### PR DESCRIPTION
linux-stable 4.14.15 commit 36ae2e6f5c01f2c01c3224969f676b1b3b547aaf
a backport of mainline commit c96f5471ce7d2aefd0dda560cc23f08ab00bc65d
changed the definition of delayacct_blkio_end()
from extern void __delayacct_blkio_end(void);
to extern void __delayacct_blkio_end(struct task_struct *);
Add version checks and adjust the MuQSS.c calls to match.