### PR TITLE
MuQSS.c needs irq_regs.h to use get_irq_regs

### DIFF
--- a/kernel/sched/MuQSS.c
+++ b/kernel/sched/MuQSS.c
@@ -70,6 +70,14 @@
 
 #include "MuQSS.h"
 
+/* needing to include irq_regs.h, "because reasons"...
+ * implicit declaration of function ‘get_irq_regs’;
+ * did you mean ‘get_ibs_caps’?
+ * [-Werror=implicit-function-declaration]
+ * ^ this is because autodetect is not flawless
+ */
+#include <asm/irq_regs.h>
+
 #define rt_prio(prio)		unlikely((prio) < MAX_RT_PRIO)
 #define rt_task(p)		rt_prio((p)->prio)
 #define batch_task(p)		(unlikely((p)->policy == SCHED_BATCH))


### PR DESCRIPTION
```
kernel/sched/MuQSS.c: In function ‘update_cpu_clock_tick’:
kernel/sched/MuQSS.c:2988:16: error: implicit declaration of function ‘get_irq_regs’; did you mean ‘get_ibs_caps’? [-Werror=implicit-function-declaration]
  if (user_mode(get_irq_regs()))
                ^~~~~~~~~~~~
```