### PR TITLE
Sync runqueue/cpu definitions with mainline

### DIFF
--- a/kernel/sched/MuQSS.c
+++ b/kernel/sched/MuQSS.c
@@ -233,12 +233,6 @@ static int total_runqueues __read_mostly = 1;
 
 static cpumask_t cpu_idle_map ____cacheline_aligned_in_smp;
 
-struct rq *cpu_rq(int cpu)
-{
-	return &per_cpu(runqueues, (cpu));
-}
-#define cpu_curr(cpu)		(cpu_rq(cpu)->curr)
-
 /*
  * For asym packing, by default the lower numbered cpu has higher priority.
  */

--- a/kernel/sched/MuQSS.h
+++ b/kernel/sched/MuQSS.h
@@ -382,9 +382,11 @@ extern struct rq *uprq;
 #define cpu_curr(cpu)	((uprq)->curr)
 #else /* CONFIG_SMP */
 DECLARE_PER_CPU_SHARED_ALIGNED(struct rq, runqueues);
+#define cpu_rq(cpu)		(&per_cpu(runqueues, (cpu)))
 #define this_rq()		this_cpu_ptr(&runqueues)
-#define raw_rq()		raw_cpu_ptr(&runqueues)
 #define task_rq(p)		cpu_rq(task_cpu(p))
+#define cpu_curr(cpu)		(cpu_rq(cpu)->curr)
+#define raw_rq()		raw_cpu_ptr(&runqueues)
 #endif /* CONFIG_SMP */
 
 static inline int task_current(struct rq *rq, struct task_struct *p)


### PR DESCRIPTION
While porting MuQSS to 5.13 in Zen Kernel (https://github.com/zen-kernel/zen-kernel/commits/5.13/muqss), I found that the runqueue definitions in the MuQSS headers were completely out of sync with mainline.  While out of sync, a change to PSI broke MuQSS builds.

The two commits listed get the runqueue definitions back in sync with mainline.